### PR TITLE
Support new attributes for reporting

### DIFF
--- a/Tests/Transport/InfobipApiTransportFactoryTest.php
+++ b/Tests/Transport/InfobipApiTransportFactoryTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Mailer\Bridge\Infobip\Tests\Transport;
 
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipApiTransport;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipTransportFactory;
@@ -24,10 +26,10 @@ class InfobipApiTransportFactoryTest extends TransportFactoryTestCase
 {
     public function getFactory(): TransportFactoryInterface
     {
-        return new InfobipTransportFactory($this->getDispatcher(), $this->getClient(), $this->getLogger());
+        return new InfobipTransportFactory(null, new MockHttpClient(), new NullLogger());
     }
 
-    public function supportsProvider(): iterable
+    public static function supportsProvider(): iterable
     {
         yield [
             new Dsn('infobip+api', 'default'),
@@ -55,33 +57,32 @@ class InfobipApiTransportFactoryTest extends TransportFactoryTestCase
         ];
     }
 
-    public function createProvider(): iterable
+    public static function createProvider(): iterable
     {
-        $dispatcher = $this->getDispatcher();
-        $logger = $this->getLogger();
+        $logger = new NullLogger();
 
         yield [
             new Dsn('infobip+api', 'example.com', self::PASSWORD),
-            (new InfobipApiTransport(self::PASSWORD, $this->getClient(), $dispatcher, $logger))->setHost('example.com'),
+            (new InfobipApiTransport(self::PASSWORD, new MockHttpClient(), null, $logger))->setHost('example.com'),
         ];
 
         yield [
             new Dsn('infobip', 'default', self::PASSWORD),
-            new InfobipSmtpTransport(self::PASSWORD, $dispatcher, $logger),
+            new InfobipSmtpTransport(self::PASSWORD, null, $logger),
         ];
 
         yield [
             new Dsn('infobip+smtp', 'default', self::PASSWORD),
-            new InfobipSmtpTransport(self::PASSWORD, $dispatcher, $logger),
+            new InfobipSmtpTransport(self::PASSWORD, null, $logger),
         ];
 
         yield [
             new Dsn('infobip+smtps', 'default', self::PASSWORD),
-            new InfobipSmtpTransport(self::PASSWORD, $dispatcher, $logger),
+            new InfobipSmtpTransport(self::PASSWORD, null, $logger),
         ];
     }
 
-    public function unsupportedSchemeProvider(): iterable
+    public static function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('infobip+foo', 'infobip', self::USER, self::PASSWORD),
@@ -89,7 +90,7 @@ class InfobipApiTransportFactoryTest extends TransportFactoryTestCase
         ];
     }
 
-    public function incompleteDsnProvider(): iterable
+    public static function incompleteDsnProvider(): iterable
     {
         yield [new Dsn('infobip+smtp', 'default')];
         yield [new Dsn('infobip+api', 'default')];

--- a/Transport/InfobipApiTransport.php
+++ b/Transport/InfobipApiTransport.php
@@ -35,6 +35,13 @@ final class InfobipApiTransport extends AbstractApiTransport
 {
     private const API_VERSION = '2';
 
+    private const HEADER_TO_MESSAGE = [
+        'X-Infobip-IntermediateReport' => 'intermediateReport',
+        'X-Infobip-NotifyUrl' => 'notifyUrl',
+        'X-Infobip-NotifyContentType' => 'notifyContentType',
+        'X-Infobip-MessageId' => 'messageId',
+    ];
+
     private string $key;
 
     public function __construct(string $key, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
@@ -124,6 +131,12 @@ final class InfobipApiTransport extends AbstractApiTransport
         }
 
         $this->attachmentsFormData($fields, $email);
+
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($convertConf = self::HEADER_TO_MESSAGE[$header->getName()] ?? false) {
+                $fields[$convertConf] = $header->getBodyAsString();
+            }
+        }
 
         return new FormDataPart($fields);
     }

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         }
     ],
     "require": {
-        "php": ">=7.4.5",
-        "symfony/mailer": "^5.4|^6.0",
-        "symfony/framework-bundle": "^5.4|^6.0"
+        "php": ">=8.1",
+        "symfony/mailer": "^6.2.7",
+        "symfony/mime": "^5.4.13|~6.0.13|^6.1.5"
     },
     "require-dev": {
-        "symfony/http-client": "^5.4|^6.0"
+        "symfony/http-client": "^6.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# 📍 Context

Infobip has a mechanism to send back SMS status like webhook do.

To do that, we need to add some attributes to the payload.

This MR aim to add this attributes.

It's a need for our company so I hope this new "feature" will be supported by the transport.

# ➕ New feature

New payload attributes was added allowing end users to use the reporting.

| Attribute | Type | Description |
| --- | --- | --- |
| X-Infobip-IntermediateReport | boolean | The real-time Intermediate delivery report that will be sent on your callback server. | 
| X-Infobip-NotifyUrl | string | The URL on your callback server on which the Delivery report will be sent. | 
| X-Infobip-NotifyContentType | string | Preferred Delivery report content type. Can be `application/json` or `application/xml`. |
| X-Infobip-MessageId | string | The ID that uniquely identifies the message sent to a recipient. |

ℹ️ Note that no one of this attributes are required.